### PR TITLE
Fail curl call on server error

### DIFF
--- a/runck
+++ b/runck
@@ -51,9 +51,9 @@ retrieve() {
     cat
   elif command -v curl >/dev/null 2>/dev/null ; then
     if tty -s ; then
-      curl_options="-sSL#"
+      curl_options="-sSLf#"
     else
-      curl_options="-sSL"
+      curl_options="-sSLf"
     fi
     curl ${curl_options} "${url}"
   else


### PR DESCRIPTION
Make the script fail if curl call gets a server error (i.e. 404 Not Found) instead of trying to execute it later