### PR TITLE
Catch interactive call

### DIFF
--- a/runck
+++ b/runck
@@ -54,6 +54,15 @@ else
   tmpfile=${TMPDIR:-/tmp}/runck-$$-$(date +%S)
 fi
 
+if [ -t 0 ]; then
+    if [ "x${url}" = "x" ]; then
+        echo "Interactive mode and no url was specified"
+        echo ""
+        printUsage
+        exit 1
+    fi
+fi
+
 cleanup() {
   rm -f "${tmpfile}"
 }
@@ -92,6 +101,8 @@ launch() {
   if [ "x${cmd}" = "x" ] ; then
     chmod 0755 "${tmpfile}"
   fi
+
+  echo ""
 
   ${cmd} "${tmpfile}" "$@"
 }

--- a/runck
+++ b/runck
@@ -91,8 +91,8 @@ retrieve() {
 validate() {
   if [ "x${checksum}" != "x" ] ; then
     checksum=$(echo ${checksum} | sed 's/^sha256://')
-    echo CK=$checksum
-    echo "${checksum}  ${tmpfile}" | sha256sum -c -
+    echo "CK=$checksum" 1>&2
+    echo "${checksum}  ${tmpfile}" | sha256sum -c - 1>&2
   fi
 }
 
@@ -102,8 +102,6 @@ launch() {
   if [ "x${cmd}" = "x" ] ; then
     chmod 0755 "${tmpfile}"
   fi
-
-  echo ""
 
   ${cmd} "${tmpfile}" "$@"
 }

--- a/runck
+++ b/runck
@@ -41,6 +41,7 @@ while [ "$#" -gt 0 ] ; do
       break
       ;;
     *)
+      shift
       break
       ;;
   esac


### PR DESCRIPTION
Catch interactive call and fail if no url has been specified.
This change avoid the script waiting on stdin if you execute it with no arguments but still allow to use pipes like:
```
cat ./runck | ./runck -c <sha256sum> -- -h
```